### PR TITLE
[FIX] Encoder for ARP 'Scale' should be 'knob' instead of 'selector'

### DIFF
--- a/src/config/synth.js
+++ b/src/config/synth.js
@@ -39,7 +39,7 @@ const defaultControls = {
     },
     118: {
         label: "Scale",
-        type: "selector",
+        type: "knob",
         options: [
             "Octave",
             "Maj Triad",


### PR DESCRIPTION
Per issue https://github.com/oscarrc/nts-web/issues/36